### PR TITLE
feat: add exponential backoff

### DIFF
--- a/src/pymedx/api.py
+++ b/src/pymedx/api.py
@@ -1,6 +1,7 @@
 """API module for PubMed."""
 import datetime
 import itertools
+import random
 import time
 
 from typing import Any, Dict, Iterable, List, Union, cast
@@ -168,6 +169,8 @@ class PubMed:
         backoff_time = min(
             2**attempt, 32
         )  # Exponential backoff, capped at 32 seconds
+
+        backoff_time += random.uniform(0, 1)  # Add jitter
 
         time.sleep(backoff_time)
 

--- a/src/pymedx/api.py
+++ b/src/pymedx/api.py
@@ -1,6 +1,7 @@
 """API module for PubMed."""
 import datetime
 import itertools
+import time
 
 from typing import Any, Dict, Iterable, List, Union, cast
 
@@ -50,6 +51,7 @@ class PubMed:
 
         # Keep track of the rate limit
         self._rateLimit: int = 3
+        self._maxRetries: int = 10
         self._requestsMade: List[datetime.datetime] = []
         self.parameters: Dict[str, Union[str, int, List[str]]]
         # Define the standard / default query parameters
@@ -154,6 +156,21 @@ class PubMed:
         # than the rate limit
         return len(self._requestsMade) > self._rateLimit
 
+    def _wait_to_retry(self, attempt: int) -> None:
+        """
+        Calculate and wait the appropriate amount of time before a retry.
+
+        Parameters.
+        ----------
+        attempt: int
+            The current attempt number.
+        """
+        backoff_time = min(
+            2**attempt, 32
+        )  # Exponential backoff, capped at 32 seconds
+
+        time.sleep(backoff_time)
+
     def _get(
         self,
         url: str,
@@ -180,27 +197,38 @@ class PubMed:
                             be parsed before returning, otherwise a string is
                             returend
         """
-        # Make sure the rate limit is not exceeded
+        attempt = 0
+
         while self._exceededRateLimit():
             pass
 
-        # Set the response mode
+        while attempt < self._maxRetries:
+            try:
+                # Set the response mode
+                parameters["retmode"] = output
 
-        parameters["retmode"] = output
+                # Make the request to PubMed
+                response = requests.get(f"{BASE_URL}{url}", params=parameters)
+                # Check for any errors
+                response.raise_for_status()
 
-        # Make the request to PubMed
-        response = requests.get(f"{BASE_URL}{url}", params=parameters)
-        # Check for any errors
-        response.raise_for_status()
+                # Add this request to the list of requests made
+                self._requestsMade.append(datetime.datetime.now())
 
-        # Add this request to the list of requests made
-        self._requestsMade.append(datetime.datetime.now())
+                # Return the response
+                if output == "json":
+                    return response.json()
+                else:
+                    return response.text
 
-        # Return the response
-        if output == "json":
-            return response.json()
-        else:
-            return response.text
+            except Exception:
+                self._wait_to_retry(attempt)
+                attempt += 1
+
+        raise Exception(
+            f"Failed to retrieve data from {BASE_URL}{url} "
+            f"after {self._maxRetries} attempts"
+        )
 
     def _getArticles(
         self, article_ids: List[str]


### PR DESCRIPTION
## Pull Request description

This PR aims to implement a exponential backoff. pymedx fetch data from a remote server (PubMed). This operation can fail for a myriad of reasons – network issues, server overload, brief disruptions in service, etc. If the application simply gives up after the first failure, it risks missing out on the opportunity to succeed in a subsequent attempt. 
This is where retrying comes in as a basic yet crucial mechanism. So in other words If the first attempt did not succeed  pymedx will wait for 2 seconds, if the second attempt fail pymedx will wait for 4 seconds and so on, the sequence in waiting times is 0 2 4 8 16 32 32 32 32 (seconds). Notice that is caped at 32 seconds

I added a jitter as well which is added to backoff_time and is a float number between 0 and 1. The addition of a random “jitter” avoids the scenario where many clients, following the same exponential backoff algorithm, retry simultaneously.

- Constants added maxRetires = 10
- New function wait_to_retry
 
## Pull Request checklists

This PR is a:

- [ ] bug-fix
- [ ] new feature
- [ ] maintenance

About this PR:

- [ ] it includes tests.
- [ ] the tests are executed on CI.
- [ ] the tests generate log file(s) (path).
- [ ] pre-commit hooks were executed locally.
- [ ] this PR requires a project documentation update.

Author's checklist:

- [ ] I have reviewed the changes and it contains no misspelling.
- [ ] The code is well commented, especially in the parts that contain more
      complexity.
- [ ] New and old tests passed locally.

## Additional information

<!-- Add any screenshot that helps to show the changes proposed -->

<!-- Add any other extra information that would help to understand the changes proposed by this PR -->

## Reviewer's checklist

Copy and paste this template for your review's note:

```
## Reviewer's Checklist

- [ ] I managed to reproduce the problem locally from the `main` branch
- [ ] I managed to test the new changes locally
- [ ] I confirm that the issues mentioned were fixed/resolved .
```
